### PR TITLE
Enable reaction to planner failure in the planner logic

### DIFF
--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
@@ -76,8 +76,6 @@ private:
   // Global planner instance
   std::shared_ptr<GlobalPlannerInterface> global_planner_instance_;
 
-  moveit_msgs::msg::MotionPlanResponse last_global_solution_;
-
   // Global planning request action server
   rclcpp_action::Server<moveit_msgs::action::GlobalPlanner>::SharedPtr global_planning_request_server_;
 

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
@@ -135,9 +135,6 @@ void GlobalPlannerComponent::globalPlanningRequestCallback(
     goal_handle->abort(result);
   }
 
-  // Save newest planning solution
-  last_global_solution_ = planning_solution;  // TODO(sjahr) Add Service to expose this
-
   // Reset the global planner
   global_planner_instance_->reset();
 };

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
@@ -119,25 +119,25 @@ void GlobalPlannerComponent::globalPlanningRequestCallback(
 {
   // Plan global trajectory
   moveit_msgs::msg::MotionPlanResponse planning_solution = global_planner_instance_->plan(goal_handle);
+
+  // Send action response
+  auto result = std::make_shared<moveit_msgs::action::GlobalPlanner::Result>();
+  result->response = planning_solution;
+
   if (planning_solution.error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
   {
     // Publish global planning solution to the local planner
     global_trajectory_pub_->publish(planning_solution);
-
-    // Send action response
-    auto result = std::make_shared<moveit_msgs::action::GlobalPlanner::Result>();
-    result->response = planning_solution;
     goal_handle->succeed(result);
-
-    // Save newest planning solution
-    last_global_solution_ = planning_solution;  // TODO(sjahr) Add Service to expose this
   }
   else
   {
-    auto result = std::make_shared<moveit_msgs::action::GlobalPlanner::Result>();
-    result->response = planning_solution;
     goal_handle->abort(result);
   }
+
+  // Save newest planning solution
+  last_global_solution_ = planning_solution;  // TODO(sjahr) Add Service to expose this
+
   // Reset the global planner
   global_planner_instance_->reset();
 };

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_events.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_events.h
@@ -46,13 +46,13 @@ enum class HybridPlanningEvent
 {
   // Occurs when the hybrid planning manager receives a planning request
   HYBRID_PLANNING_REQUEST_RECEIVED,
-  // Indicates that the global planning action finished
+  // Result of the global planning action
   GLOBAL_PLANNING_ACTION_SUCCESSFUL,
   GLOBAL_PLANNING_ACTION_ABORTED,
   GLOBAL_PLANNING_ACTION_CANCELED,
   // Indicates that the global planner found a solution (This solution is not necessarily the last or best solution)
   GLOBAL_SOLUTION_AVAILABLE,
-  // Indicates that the local planning action finished
+  // Result of the local planning action
   LOCAL_PLANNING_ACTION_SUCCESSFUL,
   LOCAL_PLANNING_ACTION_ABORTED,
   LOCAL_PLANNING_ACTION_CANCELED,

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_events.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_events.h
@@ -46,12 +46,17 @@ enum class HybridPlanningEvent
 {
   // Occurs when the hybrid planning manager receives a planning request
   HYBRID_PLANNING_REQUEST_RECEIVED,
-  // Indicates that the global planning action finished (Does not indicate planning success! The action response
-  // contains this information)
-  GLOBAL_PLANNING_ACTION_FINISHED,
+  // Indicates that the global planning action finished
+  GLOBAL_PLANNING_ACTION_SUCCESSFUL,
+  GLOBAL_PLANNING_ACTION_ABORTED,
+  GLOBAL_PLANNING_ACTION_CANCELED,
   // Indicates that the global planner found a solution (This solution is not necessarily the last or best solution)
   GLOBAL_SOLUTION_AVAILABLE,
-  // Indicates that the local planning action finished (Does not indicate planning success! The action response contains this information)
-  LOCAL_PLANNING_ACTION_FINISHED,
+  // Indicates that the local planning action finished
+  LOCAL_PLANNING_ACTION_SUCCESSFUL,
+  LOCAL_PLANNING_ACTION_ABORTED,
+  LOCAL_PLANNING_ACTION_CANCELED,
+  // Undefined event to allow empty reaction events to indicate failure
+  UNDEFINED
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/planner_logic_interface.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/planner_logic_interface.h
@@ -56,15 +56,29 @@ struct ReactionResult
       case HybridPlanningEvent::HYBRID_PLANNING_REQUEST_RECEIVED:
         event = "Hybrid planning request received";
         break;
-      case HybridPlanningEvent::GLOBAL_PLANNING_ACTION_FINISHED:
-        event = "Global planning action finished";
+      case HybridPlanningEvent::GLOBAL_PLANNING_ACTION_SUCCESSFUL:
+        event = "Global planning action successful";
+        break;
+      case HybridPlanningEvent::GLOBAL_PLANNING_ACTION_ABORTED:
+        event = "Global planning action aborted";
+        break;
+      case HybridPlanningEvent::GLOBAL_PLANNING_ACTION_CANCELED:
+        event = "Global planning action canceled";
         break;
       case HybridPlanningEvent::GLOBAL_SOLUTION_AVAILABLE:
         event = "Global solution available";
         break;
-      case HybridPlanningEvent::LOCAL_PLANNING_ACTION_FINISHED:
-        event = "Local planning action finished";
+      case HybridPlanningEvent::LOCAL_PLANNING_ACTION_SUCCESSFUL:
+        event = "Local planning action successful";
         break;
+      case HybridPlanningEvent::LOCAL_PLANNING_ACTION_ABORTED:
+        event = "Local planning action aborted";
+        break;
+      case HybridPlanningEvent::LOCAL_PLANNING_ACTION_CANCELED:
+        event = "Local planning action canceled";
+        break;
+      case HybridPlanningEvent::UNDEFINED:
+        event = "Undefined event";
     }
   };
   ReactionResult(const std::string& event, const std::string& error_msg, const int& error_code)

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/include/moveit/planner_logic_plugins/single_plan_execution.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/include/moveit/planner_logic_plugins/single_plan_execution.h
@@ -50,5 +50,8 @@ public:
   bool initialize(const std::shared_ptr<HybridPlanningManager>& hybrid_planning_manager) override;
   ReactionResult react(const HybridPlanningEvent& event) override;
   ReactionResult react(const std::string& event) override;
+
+private:
+  bool local_planner_started_ = false;
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/src/single_plan_execution.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/src/single_plan_execution.cpp
@@ -75,7 +75,7 @@ ReactionResult SinglePlanExecution::react(const HybridPlanningEvent& event)
       }
       return ReactionResult(event, "", moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
     case HybridPlanningEvent::GLOBAL_PLANNING_ACTION_ABORTED:
-      // Abort hybrid planning if now global solution is found
+      // Abort hybrid planning if no global solution is found
       return ReactionResult(event, "Global planner failed to find a solution",
                             moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED);
     case HybridPlanningEvent::LOCAL_PLANNING_ACTION_SUCCESSFUL:


### PR DESCRIPTION
# Description
I've addressed the inability to react in the logic to a failure of the global/local planner action by adding additional Hybrid Planning events. This way it is possible to define the reaction to those events in the planner logic plugin and make it easy to customize this behavior.
Additionally, I fixed the issue @JensVanhooydonck mentioned in #763 that it is not possible to send multiple consecutive hybrid planning requests by simply adding a bool flag.
 
@AndyZe and @JensVanhooydonck can you verify that this works?

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
