### PR TITLE
CMake fix and cleanup abstract class

### DIFF
--- a/moveit_ros/hybrid_planning/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/CMakeLists.txt
@@ -92,7 +92,7 @@ pluginlib_export_plugin_description_file(moveit_hybrid_planning simple_sampler_p
 pluginlib_export_plugin_description_file(moveit_hybrid_planning replan_invalidated_trajectory_plugin.xml)
 pluginlib_export_plugin_description_file(moveit_hybrid_planning forward_trajectory_plugin.xml)
 
-ament_export_include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
+ament_export_include_directories(include)
 ament_export_libraries(${LIBRARIES})
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/moveit_ros/hybrid_planning/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/CMakeLists.txt
@@ -68,8 +68,14 @@ rclcpp_components_register_nodes(moveit_hybrid_planning_manager "moveit::hybrid_
 rclcpp_components_register_nodes(moveit_global_planner_component "moveit::hybrid_planning::GlobalPlannerComponent")
 rclcpp_components_register_nodes(moveit_local_planner_component "moveit::hybrid_planning::LocalPlannerComponent")
 
-install(TARGETS ${LIBRARIES} hybrid_planning_demo_node
+install(TARGETS ${LIBRARIES}
   EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  INCLUDES DESTINATION include)
+
+install(TARGETS hybrid_planning_demo_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/trajectory_operator_interface.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/trajectory_operator_interface.h
@@ -101,9 +101,6 @@ public:
    */
   virtual bool reset() = 0;
 
-  /** \brief Return the most recent target waypoint index */
-  virtual size_t getTargetWayPointIndex() = 0;
-
 protected:
   // Reference trajectory to be precessed
   robot_trajectory::RobotTrajectoryPtr reference_trajectory_;

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
@@ -58,7 +58,7 @@ public:
                      robot_trajectory::RobotTrajectory& local_trajectory) override;
   double getTrajectoryProgress(const moveit::core::RobotState& current_state) override;
   bool reset() override;
-  size_t getTargetWayPointIndex() override;
+  size_t getTargetWayPointIndex();
 
 private:
   std::size_t

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
@@ -58,7 +58,6 @@ public:
                      robot_trajectory::RobotTrajectory& local_trajectory) override;
   double getTrajectoryProgress(const moveit::core::RobotState& current_state) override;
   bool reset() override;
-  size_t getTargetWayPointIndex();
 
 private:
   std::size_t

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -119,11 +119,6 @@ SimpleSampler::getLocalTrajectory(const moveit::core::RobotState& current_state,
   return feedback_;
 }
 
-size_t SimpleSampler::getTargetWayPointIndex()
-{
-  return next_waypoint_index_;
-}
-
 double SimpleSampler::getTrajectoryProgress(const moveit::core::RobotState& current_state)
 {
   // Check if trajectory is unwinded


### PR DESCRIPTION
### Description
When I tried to add hybrid planning as a dependency in a different package I got several CMake errors/warnings like this:
```
CMake Warning at /home/sebi/ws_thesis/install/moveit_hybrid_planning/share/moveit_hybrid_planning/cmake/ament_cmake_export_include_directories-extras.cmake:11 (message):
  Package 'moveit_hybrid_planning' exports the include directory
  '/home/sebi/ws_thesis/install/moveit_hybrid_planning/share/moveit_hybrid_planning/cmake/../../../global_planner/global_planner_component/include/'
  which doesn't exist
Call Stack (most recent call first):
  /home/sebi/ws_thesis/install/moveit_hybrid_planning/share/moveit_hybrid_planning/cmake/moveit_hybrid_planningConfig.cmake:41 (include)
  CMakeLists.txt:5 (find_package)
```
```
CMake Error at CMakeLists.txt:17 (add_library):
  Target "mpi_solver" links to target
  "moveit_hybrid_planning::hybrid_planning_demo_node" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?

```
I fixed them by installing the hybrid_planning_demo_node separately and thus prevented it from being exported as part of the hybrid planning dependency and by updating the exported include directory.

Furthermore, I removed the `getTargetWayPointIndex` function from the abstract class because I think it is not essential and can be added to the child class if required. I became aware that we only define it in the SimpleSampler class but never use it anywhere (except I've overlooked it somewhere). @AndyZe maybe it can be removed completely what do you think?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
